### PR TITLE
Added missing dependency "babel-preset-react-app"

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@typescript-eslint/parser": "^2.2.0",
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.6",
+    "babel-preset-react-app": "^9.1.0",
     "eslint": "^6.4.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^6.3.0",


### PR DESCRIPTION
Hey there! Thanks for putting this together! It appears "babel-preset-react-app" was left out of the dependencies however. 